### PR TITLE
Alternative Collection Spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Here we try to justify this choice.
 
 - The [THREDDS Client Catalog Specification
 ](https://www.unidata.ucar.edu/software/tds/current/catalog/InvCatalogSpec.html)
-  is a excellent, full-featured, mature specification aimed at a similar type of datasets.
+  is an excellent, full-featured, mature specification aimed at a similar type of datasets.
   We probably could have used the THREDDS spec here, and avoided defining a new one.
-  However, we are not actually planning to use THREDDS
-  It is in XML and is controlled by Unidata.
+  However, we are not actually planning to use THREDDS.
+  The spec is in XML and is controlled by Unidata (not open for pull requests).
   For the cloud, some innovation is likely needed.
   We were looking for something simpler and more open to hacking from the community.
 
@@ -70,7 +70,7 @@ The descriptor is a single json file, inspired by the STAC spec.
       "vocabulary": "https://raw.githubusercontent.com/WCRP-CMIP/CMIP6_CVs/master/CMIP6_source_id.json"
     }
   ],
-  "files": {
+  "assets": {
     "column_name": "path",
     "format": "zarr"
   }
@@ -89,7 +89,7 @@ CMIP,ACCESS-CM2,gs://pangeo-data/store1.zarr
 CMIP,GISS-E2-1-G,gs://pangeo-data/store1.zarr
 ```
 
-### Data Files
+### Assets (Data Files)
 
-The data files can be either netCDF or Zarr.
+The data assets can be either netCDF or Zarr.
 They should be either URIs or full filesystem paths.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,51 @@
-# esm-collection-spec
-Earth System Model Collection specification
+# ESM Catalog Spec
+
+The Earth System Model Catalog specification describes a way of cataloging large datasets with a homogeneous metadata structure, such as those produced by the Coupled Model Intercomparison Project of the World Climate Research Programme.
+It was designed within the Pangeo project, growing out of various ad-hoc attempts at building catalogs of convenience for CMIP6 and related dataset in the months before the [2019 CMIP6 Hackathon](https://cmip6hack.github.io).
+
+## Background and Related Projects
+
+![Standards](https://imgs.xkcd.com/comics/standards.png)
+
+via <https://xkcd.com/927/>
+
+We are guilty of creating a new standard rather than reusing one of the many reasonable alternatives already in existence.
+Here we try to justify this choice.
+
+- The [THREDDS Client Catalog Specification
+](https://www.unidata.ucar.edu/software/tds/current/catalog/InvCatalogSpec.html)
+  is a excellent, full-featured, mature specification aimed at a similar type of datasets.
+  We probably could have used the THREDDS spec here, and avoided defining a new one.
+  However, we are not actually planning to use THREDDS
+  It is in XML and is controlled by Unidata.
+  For the cloud, some innovation is likely needed.
+  We were looking for something simpler and more open to hacking from the community.
+
+- [Spatiotemporal Asset Catalog](https://github.com/radiantearth/stac-spec/blob/master/README.md) was very inspirational from a technical point of view.
+  We love the simplicity of their approach, with lightweight text files optimized for cloud-native operations.
+  But STAC is aimed at geospatial imagery, which has slightly different attributes and challenges compared to climate model data.
+  Spatiotemporal assets usually show just a small piece of the real Earth, within the recent historical period.
+  Climate models generally simulate the whole planet, under hundreds or thousands of different scenarios. Not to mention weird calendars, aquaplanets, exoplanets, etc.
+  We played around with STAC, but it didn't feel like the right fit.
+
+- [AOSPy](https://aospy.readthedocs.io/en/stable/index.html) is a workflow manager aimed at similar data ensembles.
+  The data model of AOSPy is very similar to the one in ESM Catalog.
+  However, the actual data catalog is described in python code, rather than text files.
+  We would love to see AOSPy interoperate with ESM spec by parsing its catalogs and converting them into its objects.
+
+- [Intake](http://intake.readthedocs.io) is python tool for cataloging and loading data, widely used in the Pangeo community.
+  The catalogs are described in YAMl, and the content of these YAML files is coupled tightly to the python library.
+  While intake is very convenient, we thought it was important that the catalog itself be language independent.
+  We hope that, once the ESM spec is complete enough, an intake driver for parsing it should be easy to implement.
+
+
+Ultimately, with sufficient time, we probably could have adopted any of the above tools and made it work for our needs.
+The decision to make a new spec was ultimately driven by the timeline of the CMIP6 hackathon--it seemed like the fastest route.
+
+## The Specification
+
+### Catalog Descriptor
+
+### Catalog
+
+### Data Files

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ESM Catalog Spec
+# ESM Catalog Specification
 
 The Earth System Model Catalog specification describes a way of cataloging large datasets with a homogeneous metadata structure, such as those produced by the Coupled Model Intercomparison Project of the World Climate Research Programme.
 It was designed within the Pangeo project, growing out of various ad-hoc attempts at building catalogs of convenience for CMIP6 and related dataset in the months before the [2019 CMIP6 Hackathon](https://cmip6hack.github.io).
@@ -28,6 +28,9 @@ Here we try to justify this choice.
   Climate models generally simulate the whole planet, under hundreds or thousands of different scenarios. Not to mention weird calendars, aquaplanets, exoplanets, etc.
   We played around with STAC, but it didn't feel like the right fit.
 
+- Our ultimate aims are similar to those of the [Earth System Grid Federation Search Tool](https://github.com/ESGF/esg-search).
+  However, we are not actually running an ESGF node, so it didn't seem sensible to try to use that tool directly. We do, however, optionally reference the same [controlled vocabularies](https://github.com/WCRP-CMIP/CMIP6_CVs) as the ESGF search tool.  
+
 - [AOSPy](https://aospy.readthedocs.io/en/stable/index.html) is a workflow manager aimed at similar data ensembles.
   The data model of AOSPy is very similar to the one in ESM Catalog.
   However, the actual data catalog is described in python code, rather than text files.
@@ -44,8 +47,49 @@ The decision to make a new spec was ultimately driven by the timeline of the CMI
 
 ## The Specification
 
-### Catalog Descriptor
+The ESM Catalog specification consists of three parts:
+
+### Collection Specification
+
+The _collection_ specification provides metadata about the catalog, telling us what we expect to find inside and how to open it.
+The descriptor is a single json file, inspired by the STAC spec.
+
+```json
+{
+  "esmcat_version": "0.1.0",
+  "id": "sample",
+  "description": "This is a very basic sample ESM collection.",
+  "catalog_file": "sample_catalog.csv",
+  "attributes": [
+    {
+      "column_name": "activity_id",
+      "vocabulary": "https://raw.githubusercontent.com/WCRP-CMIP/CMIP6_CVs/master/CMIP6_activity_id.json"
+    },
+    {
+      "column_name": "source_id",
+      "vocabulary": "https://raw.githubusercontent.com/WCRP-CMIP/CMIP6_CVs/master/CMIP6_source_id.json"
+    }
+  ],
+  "files": {
+    "column_name": "path",
+    "format": "zarr"
+  }
+}
+```
 
 ### Catalog
 
+The collection points to a single catalog.
+A catalog is a CSV file.
+The meaning of the columns in the csv file is defined by the parent collection.
+
+```csv
+activity_id,source_id,path
+CMIP,ACCESS-CM2,gs://pangeo-data/store1.zarr
+CMIP,GISS-E2-1-G,gs://pangeo-data/store1.zarr
+```
+
 ### Data Files
+
+The data files can be either netCDF or Zarr.
+They should be either URIs or full filesystem paths.

--- a/collection-spec/collection-spec.md
+++ b/collection-spec/collection-spec.md
@@ -14,7 +14,7 @@ The collection is described is a single json file, inspired by the STAC spec.
 | description  | string        | **REQUIRED.** Detailed multi-line description to fully explain the collection. [CommonMark 0.28](http://commonmark.org/) syntax MAY be used for rich text representation. |
 | catalog_file | string | **REQUIRED.** Path to a the CSV file with the catalog contents. |
 | attributes | [[Attribute Object](#attribute-object)] | **REQUIRED.** A list of attribute columns in the dataset. |
-| assets | [Asset Object](#assets-object) | **REQUIRED**. Description o how the assets (data files) are referenced in the CSV catalog file.
+| assets | [Assets Object](#assets-object) | **REQUIRED**. Description of how the assets (data files) are referenced in the CSV catalog file.
 
 ### Attribute Object
 

--- a/collection-spec/collection-spec.md
+++ b/collection-spec/collection-spec.md
@@ -1,0 +1,37 @@
+# ESM Collection Specification
+
+This document explains the structure and content of an ESM Collection.
+A collection provides metadata about the catalog, telling us what we expect to find inside and how to open it.
+The collection is described is a single json file, inspired by the STAC spec.
+
+## Catalog fields
+
+| Element      | Type          | Description                                                  |
+| ------------ | ------------- | ------------------------------------------------------------ |
+| esmcat_version | string      | **REQUIRED.** The ESM Catalog version the collection implements. |
+| id           | string        | **REQUIRED.** Identifier for the collection.                    |
+| title        | string        | A short descriptive one-line title for the collection.          |
+| description  | string        | **REQUIRED.** Detailed multi-line description to fully explain the collection. [CommonMark 0.28](http://commonmark.org/) syntax MAY be used for rich text representation. |
+| catalog_file | string | **REQUIRED.** Path to a the CSV file with the catalog contents. |
+| attributes | [[Attribute Object](#attribute-object)] | **REQUIRED.** A list of attribute columns in the dataset. |
+| assets | [Asset Object](#assets-object) | **REQUIRED**. Description o how the assets (data files) are referenced in the CSV catalog file.
+
+### Attribute Object
+
+An attribute object describes a column in the catalog CSV file.
+The column names can optionally be associated with a controlled vocabulary, such as the [CMIP6 CVs](https://github.com/WCRP-CMIP/CMIP6_CVs), which explain how to interpret the attribute values.
+
+| Element | Type | Description |
+| ------- | ---- | ------------|
+| column_name | string | **REQUIRED.** The name of the attribute column. Must be in the header of the CSV file. |
+| vocabulary | string | Link to the controlled vocabulary for the attribute in the format of a URL. |
+
+### Assets Object
+
+An assets object describes the columns in the CSV file relevant for opening the actual data files.
+
+| Element | Type | Description |
+| ------- | ---- | ------------|
+| column_name | string | **REQUIRED.** The name of the column containing the path to the asset. Must be in the header of the CSV file. |
+| format | string | The data format. Valid values are `netcdf` and `zarr`. If specified, it means that all data in the catalog is the same type. |
+| format_column_name | string | The column name which contains the data format, allowing for variable data types in one catalog. Mutually exclusive with `format`. |

--- a/collection-spec/examples/simple-collection.json
+++ b/collection-spec/examples/simple-collection.json
@@ -1,0 +1,20 @@
+{
+  "esmcat_version": "0.1.0",
+  "id": "sample",
+  "description": "This is a very basic sample ESM collection.",
+  "catalog_file": "sample_catalog.csv",
+  "attributes": [
+    {
+      "column_name": "activity_id",
+      "vocabulary": "https://raw.githubusercontent.com/WCRP-CMIP/CMIP6_CVs/master/CMIP6_activity_id.json"
+    },
+    {
+      "column_name": "source_id",
+      "vocabulary": "https://raw.githubusercontent.com/WCRP-CMIP/CMIP6_CVs/master/CMIP6_source_id.json"
+    }
+  ],
+  "assets": {
+    "column_name": "path",
+    "format": "zarr"
+  }
+}

--- a/collection-spec/json-schema/collection.json
+++ b/collection-spec/json-schema/collection.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "catalog.json#",
+  "title": "STAC Catalog Specification",
+  "description": "This object represents Catalogs in a SpatioTemporal Asset Catalog.",
+  "allOf": [
+    {
+      "$ref": "#/definitions/catalog"
+    }
+  ],
+  "definitions": {
+    "catalog": {
+      "title": "Catalog",
+      "type": "object",
+      "required": [
+        "stac_version",
+        "id",
+        "description",
+        "links"
+      ],
+      "properties": {
+        "stac_version": {
+          "title": "STAC version",
+          "type": "string",
+          "const": "0.8.0"
+        },
+        "stac_extensions": {
+          "title": "STAC extensions",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "id": {
+          "title": "Identifier",
+          "type": "string"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "links": {
+          "title": "Links",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/link"
+          }
+        },
+        "summaries": {
+          "$ref": "#/definitions/summaries"
+        }
+      }
+    },
+    "summaries": {
+      "type": "object",
+      "additionalProperties": {
+        "oneOf": [
+          {
+            "title": "Stats",
+            "type": "object",
+            "required": [
+              "min",
+              "max"
+            ],
+            "properties": {
+              "min": {
+                "title": "Minimum value",
+                "type": ["number", "string"]
+              },
+              "max": {
+                "title": "Maximum value",
+                "type": ["number", "string"]
+              }
+            }
+          },
+          {
+            "title": "Set of values",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "description": "Any data type could occur."
+            }
+          }
+        ]
+      }
+    },
+    "link": {
+      "type": "object",
+      "required": [
+        "rel",
+        "href"
+      ],
+      "properties": {
+        "href": {
+          "title": "Link reference",
+          "type": "string"
+        },
+        "rel": {
+          "title": "Link relation type",
+          "type": "string"
+        },
+        "type": {
+          "title": "Link type",
+          "type": "string"
+        },
+        "title": {
+          "title": "Link title",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/collection-spec/json-schema/collection.json
+++ b/collection-spec/json-schema/collection.json
@@ -1,36 +1,30 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "catalog.json#",
-  "title": "STAC Catalog Specification",
-  "description": "This object represents Catalogs in a SpatioTemporal Asset Catalog.",
+  "$id": "collection.json#",
+  "title": "ESM Collection Specification",
+  "description": "This object represents Collections in a Earth System Model Catalog.",
   "allOf": [
     {
-      "$ref": "#/definitions/catalog"
+      "$ref": "#/definitions/collection"
     }
   ],
   "definitions": {
-    "catalog": {
-      "title": "Catalog",
+    "collection": {
+      "title": "Collection",
       "type": "object",
       "required": [
-        "stac_version",
+        "esmcat_version",
         "id",
         "description",
-        "links"
+        "catalog_file",
+        "attributes",
+        "assets"
       ],
       "properties": {
-        "stac_version": {
-          "title": "STAC version",
+        "esmcat_version": {
+          "title": "ESM Catalog version",
           "type": "string",
-          "const": "0.8.0"
-        },
-        "stac_extensions": {
-          "title": "STAC extensions",
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "type": "string"
-          }
+          "const": "0.1.0"
         },
         "id": {
           "title": "Identifier",
@@ -44,72 +38,59 @@
           "title": "Description",
           "type": "string"
         },
-        "links": {
-          "title": "Links",
+        "catalog_file": {
+          "title": "Catalog File",
+          "type": "string"
+        },
+        "attributes": {
+          "title": "Attributes",
+          "description": "Asset attributes",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/link"
+            "$ref": "#/definitions/attribute"
           }
         },
-        "summaries": {
-          "$ref": "#/definitions/summaries"
+        "assets": {
+          "title": "Assets",
+          "description": "Assets file",
+          "type": "object",
+          "required": [
+              "column_name"
+            ],
+          "properties": {
+            "column_name": {
+              "title": "Column Name",
+              "description": "The name of the column containing the path to the asset.",
+              "type": "string"
+            },
+            "format": {
+              "title": "Format",
+              "description": "File format of the assets.",
+              "type": "string"
+            },
+            "format_column_name": {
+              "title": "Format Column Name",
+              "description": "The column name which contains the data format.",
+              "type": "string"
+            }
+          }
         }
       }
     },
-    "summaries": {
-      "type": "object",
-      "additionalProperties": {
-        "oneOf": [
-          {
-            "title": "Stats",
-            "type": "object",
-            "required": [
-              "min",
-              "max"
-            ],
-            "properties": {
-              "min": {
-                "title": "Minimum value",
-                "type": ["number", "string"]
-              },
-              "max": {
-                "title": "Maximum value",
-                "type": ["number", "string"]
-              }
-            }
-          },
-          {
-            "title": "Set of values",
-            "type": "array",
-            "minItems": 1,
-            "items": {
-              "description": "Any data type could occur."
-            }
-          }
-        ]
-      }
-    },
-    "link": {
+    "attribute": {
       "type": "object",
       "required": [
-        "rel",
-        "href"
+        "column_name"
       ],
       "properties": {
-        "href": {
-          "title": "Link reference",
+        "column_name": {
+          "title": "Column Name",
+          "description": "Name of the attribute column in the assets csv file.",
           "type": "string"
         },
-        "rel": {
-          "title": "Link relation type",
-          "type": "string"
-        },
-        "type": {
-          "title": "Link type",
-          "type": "string"
-        },
-        "title": {
-          "title": "Link title",
+        "vocabulary": {
+          "title": "Vocabulary",
+          "description": "Link to the controlled vocabulary for the attribute in the format of a URL.",
           "type": "string"
         }
       }


### PR DESCRIPTION
My alternative to #3...

This tries to mirror STAC much more closely. The collection spec is in json, and the vocabulary is similar.

So far there is nothing in here about merging, concatenating, etc. I really think that is a separate problem from simply describing file assets and should be tackled only once the base spec is established.

Todo:
- [x] finish `collection-spec/json-schema/collection.json`. Right now it's just copied verbatim from the STAC collection schema.
- [ ] define the fields for suggested merging / concatenating.