### PR TITLE
Use relative links

### DIFF
--- a/collection-spec/examples/sample-glade-cmip6-netcdf-collection.json
+++ b/collection-spec/examples/sample-glade-cmip6-netcdf-collection.json
@@ -2,7 +2,7 @@
   "esmcat_version": "0.1.0",
   "id": "glade-cmip6",
   "description": "This is an ESM collection for CMIP6 data residing on NCAR's GLADE file system.",
-  "catalog_file": "https://raw.githubusercontent.com/NCAR/esm-collection-spec/master/collection-spec/examples/sample-glade-cmip6-netcdf.csv",
+  "catalog_file": "sample-glade-cmip6-netcdf.csv",
   "attributes": [
     {
       "column_name": "activity_id",

--- a/collection-spec/examples/sample-pangeo-cmip6-collection.json
+++ b/collection-spec/examples/sample-pangeo-cmip6-collection.json
@@ -2,7 +2,7 @@
   "esmcat_version": "0.1.0",
   "id": "pangeo-cmip6",
   "description": "This is an ESM collection for CMIP6 Zarr data residing in Pangeo's Google Storage.",
-  "catalog_file": "https://raw.githubusercontent.com/NCAR/esm-collection-spec/master/collection-spec/examples/sample-cmip6-zarr-stores.csv",
+  "catalog_file": "sample-cmip6-zarr-stores.csv",
   "attributes": [
     {
       "column_name": "activity_id",


### PR DESCRIPTION
I should have caught this on #7...

I think we should use relative links in the examples, rather than absolute URLs (which might change,  e.g. in test environments).