### PR TITLE
Add catalog_dict examples

### DIFF
--- a/examples/sample-catalog-dict-assets.json
+++ b/examples/sample-catalog-dict-assets.json
@@ -1,5 +1,5 @@
 {
-  "stac_version": "0.9.0",
+  "stac_version": "1.0.0-beta.1",
   "stac_extensions": [
     "collection-assets",
     "https://github.com/NCAR/esm-collection-spec/tree/master/schema.json"

--- a/examples/sample-catalog-dict-assets.json
+++ b/examples/sample-catalog-dict-assets.json
@@ -53,19 +53,19 @@
       "href": "https://raw.githubusercontent.com/WCRP-CMIP/CMIP6_CVs/master/CMIP6_institution_id.json",
       "type": "application/json",
       "roles": ["esm-vocabulary"],
-      "esm:column_name": "institution_id"
+      "esm:attribute_field": "institution_id"
     },
     "source_id": {
       "href": "https://raw.githubusercontent.com/WCRP-CMIP/CMIP6_CVs/master/CMIP6_source_id.json",
       "type": "application/json",
       "roles": ["esm-vocabulary"],
-      "esm:column_name": "source_id"
+      "esm:attribute_field": "source_id"
     },
     "experiment_id": {
       "href": "https://raw.githubusercontent.com/WCRP-CMIP/CMIP6_CVs/master/CMIP6_experiment_id.json",
       "type": "application/json",
       "roles": ["esm-vocabulary"],
-      "esm:column_name": "experiment_id"
+      "esm:attribute_field": "experiment_id"
     },
     "0": {
       "institution_id": "NOAA-GFDL",

--- a/examples/sample-catalog-dict-assets.json
+++ b/examples/sample-catalog-dict-assets.json
@@ -1,0 +1,176 @@
+{
+  "stac_version": "0.9.0",
+  "stac_extensions": [
+    "collection-assets",
+    "https://github.com/NCAR/esm-collection-spec/tree/master/schema.json"
+  ],
+  "id": "GFDL_CM2_6_GCP",
+  "title": "GFDL CM2.6 GCP",
+  "description": "GFDL CM2.6 zarr data residing in Google Storage.",
+  "extent": {
+    "spatial": {
+      "bbox": [
+        [-180, -90, 180, 90]
+      ]
+    },
+    "temporal": {
+      "interval": [
+        ["1850-01-15T12:00:00Z", "2014-12-15T12:00:00Z"]
+      ]
+    }
+  },
+  "providers": [{
+      "name": "Geophysical Fluid Dynamics Laboratory",
+      "roles": ["producer", "licensor"],
+      "url": "https://www.gfdl.noaa.gov/"
+    },
+    {
+      "name": "Pangeo",
+      "roles": ["processor"],
+      "url": "https://console.cloud.google.com/pangeo.io"
+    },
+    {
+      "name": "Google",
+      "roles": ["host"],
+      "url": "https://console.cloud.google.com/marketplace/details/noaa-public/cmip6"
+    }
+  ],
+  "license": "proprietary",
+  "links": [{
+    "href": "https://pcmdi.llnl.gov/CMIP6/TermsOfUse/TermsOfUse6-1.html",
+    "type": "text/html",
+    "rel": "license",
+    "title": "CMIP6: Terms of Use"
+  }],
+  "assets": {
+    "thumbnail": {
+      "href": "logo.png",
+      "title": "A preview image for visualization.",
+      "type": "image/png",
+      "roles": ["thumbnail"]
+    },
+    "institution_id": {
+      "href": "https://raw.githubusercontent.com/WCRP-CMIP/CMIP6_CVs/master/CMIP6_institution_id.json",
+      "type": "application/json",
+      "roles": ["esm-vocabulary"],
+      "esm:column_name": "activity_id"
+    },
+    "source_id": {
+      "href": "https://raw.githubusercontent.com/WCRP-CMIP/CMIP6_CVs/master/CMIP6_source_id.json",
+      "type": "application/json",
+      "roles": ["esm-vocabulary"],
+      "esm:column_name": "source_id"
+    },
+    "experiment_id": {
+      "href": "https://raw.githubusercontent.com/WCRP-CMIP/CMIP6_CVs/master/CMIP6_experiment_id.json",
+      "type": "application/json",
+      "roles": ["esm-vocabulary"],
+      "esm:column_name": "experiment_id"
+    },
+    "0": {
+      "institution_id": "NOAA-GFDL",
+      "source_id": "GFDL-CM2.6",
+      "experiment_id": "control",
+      "variable_id": "ocean",
+      "zstore": "gs://cmip6/GFDL_CM2_6/control/ocean"
+    },
+    "1": {
+      "institution_id": "NOAA-GFDL",
+      "source_id": "GFDL-CM2.6",
+      "experiment_id": "control",
+      "variable_id": "ocean_3d",
+      "zstore": "gs://cmip6/GFDL_CM2_6/control/ocean_3d"
+    },
+    "2": {
+      "institution_id": "NOAA-GFDL",
+      "source_id": "GFDL-CM2.6",
+      "experiment_id": "control",
+      "variable_id": "ocean_boundary",
+      "zstore": "gs://cmip6/GFDL_CM2_6/control/ocean_boundary"
+    },
+    "3": {
+      "institution_id": "NOAA-GFDL",
+      "source_id": "GFDL-CM2.6",
+      "experiment_id": "control",
+      "variable_id": "ocean_budgets",
+      "zstore": "gs://cmip6/GFDL_CM2_6/control/ocean_budgets"
+    },
+    "4": {
+      "institution_id": "NOAA-GFDL",
+      "source_id": "GFDL-CM2.6",
+      "experiment_id": "control",
+      "variable_id": "ocean_transport",
+      "zstore": "gs://cmip6/GFDL_CM2_6/control/ocean_transport"
+    },
+    "5": {
+      "institution_id": "NOAA-GFDL",
+      "source_id": "GFDL-CM2.6",
+      "experiment_id": "control",
+      "variable_id": "surface",
+      "zstore": "gs://cmip6/GFDL_CM2_6/control/surface"
+    },
+    "6": {
+      "institution_id": "NOAA-GFDL",
+      "source_id": "GFDL-CM2.6",
+      "experiment_id": "one_percent",
+      "variable_id": "ocean",
+      "zstore": "gs://cmip6/GFDL_CM2_6/one_percent/ocean"
+    },
+    "7": {
+      "institution_id": "NOAA-GFDL",
+      "source_id": "GFDL-CM2.6",
+      "experiment_id": "one_percent",
+      "variable_id": "ocean_3d",
+      "zstore": "gs://cmip6/GFDL_CM2_6/one_percent/ocean_3d"
+    },
+    "8": {
+      "institution_id": "NOAA-GFDL",
+      "source_id": "GFDL-CM2.6",
+      "experiment_id": "one_percent",
+      "variable_id": "ocean_boundary",
+      "zstore": "gs://cmip6/GFDL_CM2_6/one_percent/ocean_boundary"
+    },
+    "9": {
+      "institution_id": "NOAA-GFDL",
+      "source_id": "GFDL-CM2.6",
+      "experiment_id": "one_percent",
+      "variable_id": "ocean_budgets",
+      "zstore": "gs://cmip6/GFDL_CM2_6/one_percent/ocean_budgets"
+    },
+    "10": {
+      "institution_id": "NOAA-GFDL",
+      "source_id": "GFDL-CM2.6",
+      "experiment_id": "one_percent",
+      "variable_id": "ocean_transport",
+      "zstore": "gs://cmip6/GFDL_CM2_6/one_percent/ocean_transport"
+    },
+    "11": {
+      "institution_id": "NOAA-GFDL",
+      "source_id": "GFDL-CM2.6",
+      "experiment_id": "one_percent",
+      "variable_id": "surface",
+      "zstore": "gs://cmip6/GFDL_CM2_6/one_percent/surface"
+    },
+    "12": {
+      "institution_id": "NOAA-GFDL",
+      "source_id": "GFDL-CM2.6",
+      "experiment_id": "grid",
+      "variable_id": "grid",
+      "zstore": "gs://cmip6/GFDL_CM2_6/grid"
+    }
+  },
+  "esm:attributes": ["institution_id", "source_id", "experiment_id", "variable_id"],
+  "esm:data_column_name": "zstore",
+  "esm:aggregation_control": {
+    "variable_column_name": "variable_id",
+    "groupby_attrs": [
+      "institution_id",
+      "source_id",
+      "experiment_id"
+    ],
+    "aggregations": [{
+      "type": "union",
+      "attribute_name": "variable_id"
+    }]
+  }
+}

--- a/examples/sample-catalog-dict-assets.json
+++ b/examples/sample-catalog-dict-assets.json
@@ -161,7 +161,7 @@
   },
   "esm:attributes": ["institution_id", "source_id", "experiment_id", "variable_id"],
   "esm:aggregation_control": {
-    "variable_column_name": "variable_id",
+    "variable": "variable_id",
     "groupby_attrs": [
       "institution_id",
       "source_id",

--- a/examples/sample-catalog-dict-assets.json
+++ b/examples/sample-catalog-dict-assets.json
@@ -53,7 +53,7 @@
       "href": "https://raw.githubusercontent.com/WCRP-CMIP/CMIP6_CVs/master/CMIP6_institution_id.json",
       "type": "application/json",
       "roles": ["esm-vocabulary"],
-      "esm:column_name": "activity_id"
+      "esm:column_name": "institution_id"
     },
     "source_id": {
       "href": "https://raw.githubusercontent.com/WCRP-CMIP/CMIP6_CVs/master/CMIP6_source_id.json",

--- a/examples/sample-catalog-dict-assets.json
+++ b/examples/sample-catalog-dict-assets.json
@@ -72,95 +72,94 @@
       "source_id": "GFDL-CM2.6",
       "experiment_id": "control",
       "variable_id": "ocean",
-      "zstore": "gs://cmip6/GFDL_CM2_6/control/ocean"
+      "href": "gs://cmip6/GFDL_CM2_6/control/ocean"
     },
     "1": {
       "institution_id": "NOAA-GFDL",
       "source_id": "GFDL-CM2.6",
       "experiment_id": "control",
       "variable_id": "ocean_3d",
-      "zstore": "gs://cmip6/GFDL_CM2_6/control/ocean_3d"
+      "href": "gs://cmip6/GFDL_CM2_6/control/ocean_3d"
     },
     "2": {
       "institution_id": "NOAA-GFDL",
       "source_id": "GFDL-CM2.6",
       "experiment_id": "control",
       "variable_id": "ocean_boundary",
-      "zstore": "gs://cmip6/GFDL_CM2_6/control/ocean_boundary"
+      "href": "gs://cmip6/GFDL_CM2_6/control/ocean_boundary"
     },
     "3": {
       "institution_id": "NOAA-GFDL",
       "source_id": "GFDL-CM2.6",
       "experiment_id": "control",
       "variable_id": "ocean_budgets",
-      "zstore": "gs://cmip6/GFDL_CM2_6/control/ocean_budgets"
+      "href": "gs://cmip6/GFDL_CM2_6/control/ocean_budgets"
     },
     "4": {
       "institution_id": "NOAA-GFDL",
       "source_id": "GFDL-CM2.6",
       "experiment_id": "control",
       "variable_id": "ocean_transport",
-      "zstore": "gs://cmip6/GFDL_CM2_6/control/ocean_transport"
+      "href": "gs://cmip6/GFDL_CM2_6/control/ocean_transport"
     },
     "5": {
       "institution_id": "NOAA-GFDL",
       "source_id": "GFDL-CM2.6",
       "experiment_id": "control",
       "variable_id": "surface",
-      "zstore": "gs://cmip6/GFDL_CM2_6/control/surface"
+      "href": "gs://cmip6/GFDL_CM2_6/control/surface"
     },
     "6": {
       "institution_id": "NOAA-GFDL",
       "source_id": "GFDL-CM2.6",
       "experiment_id": "one_percent",
       "variable_id": "ocean",
-      "zstore": "gs://cmip6/GFDL_CM2_6/one_percent/ocean"
+      "href": "gs://cmip6/GFDL_CM2_6/one_percent/ocean"
     },
     "7": {
       "institution_id": "NOAA-GFDL",
       "source_id": "GFDL-CM2.6",
       "experiment_id": "one_percent",
       "variable_id": "ocean_3d",
-      "zstore": "gs://cmip6/GFDL_CM2_6/one_percent/ocean_3d"
+      "href": "gs://cmip6/GFDL_CM2_6/one_percent/ocean_3d"
     },
     "8": {
       "institution_id": "NOAA-GFDL",
       "source_id": "GFDL-CM2.6",
       "experiment_id": "one_percent",
       "variable_id": "ocean_boundary",
-      "zstore": "gs://cmip6/GFDL_CM2_6/one_percent/ocean_boundary"
+      "href": "gs://cmip6/GFDL_CM2_6/one_percent/ocean_boundary"
     },
     "9": {
       "institution_id": "NOAA-GFDL",
       "source_id": "GFDL-CM2.6",
       "experiment_id": "one_percent",
       "variable_id": "ocean_budgets",
-      "zstore": "gs://cmip6/GFDL_CM2_6/one_percent/ocean_budgets"
+      "href": "gs://cmip6/GFDL_CM2_6/one_percent/ocean_budgets"
     },
     "10": {
       "institution_id": "NOAA-GFDL",
       "source_id": "GFDL-CM2.6",
       "experiment_id": "one_percent",
       "variable_id": "ocean_transport",
-      "zstore": "gs://cmip6/GFDL_CM2_6/one_percent/ocean_transport"
+      "href": "gs://cmip6/GFDL_CM2_6/one_percent/ocean_transport"
     },
     "11": {
       "institution_id": "NOAA-GFDL",
       "source_id": "GFDL-CM2.6",
       "experiment_id": "one_percent",
       "variable_id": "surface",
-      "zstore": "gs://cmip6/GFDL_CM2_6/one_percent/surface"
+      "href": "gs://cmip6/GFDL_CM2_6/one_percent/surface"
     },
     "12": {
       "institution_id": "NOAA-GFDL",
       "source_id": "GFDL-CM2.6",
       "experiment_id": "grid",
       "variable_id": "grid",
-      "zstore": "gs://cmip6/GFDL_CM2_6/grid"
+      "href": "gs://cmip6/GFDL_CM2_6/grid"
     }
   },
   "esm:attributes": ["institution_id", "source_id", "experiment_id", "variable_id"],
-  "esm:data_column_name": "zstore",
   "esm:aggregation_control": {
     "variable_column_name": "variable_id",
     "groupby_attrs": [

--- a/examples/sample-catalog-dict-assets.json
+++ b/examples/sample-catalog-dict-assets.json
@@ -72,6 +72,7 @@
       "source_id": "GFDL-CM2.6",
       "experiment_id": "control",
       "variable_id": "ocean",
+      "roles": ["esm-data"],
       "href": "gs://cmip6/GFDL_CM2_6/control/ocean"
     },
     "1": {
@@ -79,6 +80,7 @@
       "source_id": "GFDL-CM2.6",
       "experiment_id": "control",
       "variable_id": "ocean_3d",
+      "roles": ["esm-data"],
       "href": "gs://cmip6/GFDL_CM2_6/control/ocean_3d"
     },
     "2": {
@@ -86,6 +88,7 @@
       "source_id": "GFDL-CM2.6",
       "experiment_id": "control",
       "variable_id": "ocean_boundary",
+      "roles": ["esm-data"],
       "href": "gs://cmip6/GFDL_CM2_6/control/ocean_boundary"
     },
     "3": {
@@ -93,6 +96,7 @@
       "source_id": "GFDL-CM2.6",
       "experiment_id": "control",
       "variable_id": "ocean_budgets",
+      "roles": ["esm-data"],
       "href": "gs://cmip6/GFDL_CM2_6/control/ocean_budgets"
     },
     "4": {
@@ -100,6 +104,7 @@
       "source_id": "GFDL-CM2.6",
       "experiment_id": "control",
       "variable_id": "ocean_transport",
+      "roles": ["esm-data"],
       "href": "gs://cmip6/GFDL_CM2_6/control/ocean_transport"
     },
     "5": {
@@ -107,6 +112,7 @@
       "source_id": "GFDL-CM2.6",
       "experiment_id": "control",
       "variable_id": "surface",
+      "roles": ["esm-data"],
       "href": "gs://cmip6/GFDL_CM2_6/control/surface"
     },
     "6": {
@@ -114,6 +120,7 @@
       "source_id": "GFDL-CM2.6",
       "experiment_id": "one_percent",
       "variable_id": "ocean",
+      "roles": ["esm-data"],
       "href": "gs://cmip6/GFDL_CM2_6/one_percent/ocean"
     },
     "7": {
@@ -121,6 +128,7 @@
       "source_id": "GFDL-CM2.6",
       "experiment_id": "one_percent",
       "variable_id": "ocean_3d",
+      "roles": ["esm-data"],
       "href": "gs://cmip6/GFDL_CM2_6/one_percent/ocean_3d"
     },
     "8": {
@@ -128,6 +136,7 @@
       "source_id": "GFDL-CM2.6",
       "experiment_id": "one_percent",
       "variable_id": "ocean_boundary",
+      "roles": ["esm-data"],
       "href": "gs://cmip6/GFDL_CM2_6/one_percent/ocean_boundary"
     },
     "9": {
@@ -135,6 +144,7 @@
       "source_id": "GFDL-CM2.6",
       "experiment_id": "one_percent",
       "variable_id": "ocean_budgets",
+      "roles": ["esm-data"],
       "href": "gs://cmip6/GFDL_CM2_6/one_percent/ocean_budgets"
     },
     "10": {
@@ -142,6 +152,7 @@
       "source_id": "GFDL-CM2.6",
       "experiment_id": "one_percent",
       "variable_id": "ocean_transport",
+      "roles": ["esm-data"],
       "href": "gs://cmip6/GFDL_CM2_6/one_percent/ocean_transport"
     },
     "11": {
@@ -149,6 +160,7 @@
       "source_id": "GFDL-CM2.6",
       "experiment_id": "one_percent",
       "variable_id": "surface",
+      "roles": ["esm-data"],
       "href": "gs://cmip6/GFDL_CM2_6/one_percent/surface"
     },
     "12": {
@@ -156,6 +168,7 @@
       "source_id": "GFDL-CM2.6",
       "experiment_id": "grid",
       "variable_id": "grid",
+      "roles": ["esm-data"],
       "href": "gs://cmip6/GFDL_CM2_6/grid"
     }
   },

--- a/examples/sample-catalog-dict-attribute.json
+++ b/examples/sample-catalog-dict-attribute.json
@@ -1,0 +1,177 @@
+{
+  "stac_version": "0.9.0",
+  "stac_extensions": [
+    "collection-assets",
+    "https://github.com/NCAR/esm-collection-spec/tree/master/schema.json"
+  ],
+  "id": "GFDL_CM2_6_GCP",
+  "title": "GFDL CM2.6 GCP",
+  "description": "GFDL CM2.6 zarr data residing in Google Storage.",
+  "extent": {
+    "spatial": {
+      "bbox": [
+        [-180, -90, 180, 90]
+      ]
+    },
+    "temporal": {
+      "interval": [
+        ["1850-01-15T12:00:00Z", "2014-12-15T12:00:00Z"]
+      ]
+    }
+  },
+  "providers": [{
+      "name": "Geophysical Fluid Dynamics Laboratory",
+      "roles": ["producer", "licensor"],
+      "url": "https://www.gfdl.noaa.gov/"
+    },
+    {
+      "name": "Pangeo",
+      "roles": ["processor"],
+      "url": "https://console.cloud.google.com/pangeo.io"
+    },
+    {
+      "name": "Google",
+      "roles": ["host"],
+      "url": "https://console.cloud.google.com/marketplace/details/noaa-public/cmip6"
+    }
+  ],
+  "license": "proprietary",
+  "links": [{
+    "href": "https://pcmdi.llnl.gov/CMIP6/TermsOfUse/TermsOfUse6-1.html",
+    "type": "text/html",
+    "rel": "license",
+    "title": "CMIP6: Terms of Use"
+  }],
+  "assets": {
+    "thumbnail": {
+      "href": "logo.png",
+      "title": "A preview image for visualization.",
+      "type": "image/png",
+      "roles": ["thumbnail"]
+    },
+    "institution_id": {
+      "href": "https://raw.githubusercontent.com/WCRP-CMIP/CMIP6_CVs/master/CMIP6_institution_id.json",
+      "type": "application/json",
+      "roles": ["esm-vocabulary"],
+      "esm:column_name": "activity_id"
+    },
+    "source_id": {
+      "href": "https://raw.githubusercontent.com/WCRP-CMIP/CMIP6_CVs/master/CMIP6_source_id.json",
+      "type": "application/json",
+      "roles": ["esm-vocabulary"],
+      "esm:column_name": "source_id"
+    },
+    "experiment_id": {
+      "href": "https://raw.githubusercontent.com/WCRP-CMIP/CMIP6_CVs/master/CMIP6_experiment_id.json",
+      "type": "application/json",
+      "roles": ["esm-vocabulary"],
+      "esm:column_name": "experiment_id"
+    }
+  },
+  "esm:catalog": [{
+      "institution_id": "NOAA-GFDL",
+      "source_id": "GFDL-CM2.6",
+      "experiment_id": "control",
+      "variable_id": "ocean",
+      "zstore": "gs://cmip6/GFDL_CM2_6/control/ocean"
+    },
+    {
+      "institution_id": "NOAA-GFDL",
+      "source_id": "GFDL-CM2.6",
+      "experiment_id": "control",
+      "variable_id": "ocean_3d",
+      "zstore": "gs://cmip6/GFDL_CM2_6/control/ocean_3d"
+    },
+    {
+      "institution_id": "NOAA-GFDL",
+      "source_id": "GFDL-CM2.6",
+      "experiment_id": "control",
+      "variable_id": "ocean_boundary",
+      "zstore": "gs://cmip6/GFDL_CM2_6/control/ocean_boundary"
+    },
+    {
+      "institution_id": "NOAA-GFDL",
+      "source_id": "GFDL-CM2.6",
+      "experiment_id": "control",
+      "variable_id": "ocean_budgets",
+      "zstore": "gs://cmip6/GFDL_CM2_6/control/ocean_budgets"
+    },
+    {
+      "institution_id": "NOAA-GFDL",
+      "source_id": "GFDL-CM2.6",
+      "experiment_id": "control",
+      "variable_id": "ocean_transport",
+      "zstore": "gs://cmip6/GFDL_CM2_6/control/ocean_transport"
+    },
+    {
+      "institution_id": "NOAA-GFDL",
+      "source_id": "GFDL-CM2.6",
+      "experiment_id": "control",
+      "variable_id": "surface",
+      "zstore": "gs://cmip6/GFDL_CM2_6/control/surface"
+    },
+    {
+      "institution_id": "NOAA-GFDL",
+      "source_id": "GFDL-CM2.6",
+      "experiment_id": "one_percent",
+      "variable_id": "ocean",
+      "zstore": "gs://cmip6/GFDL_CM2_6/one_percent/ocean"
+    },
+    {
+      "institution_id": "NOAA-GFDL",
+      "source_id": "GFDL-CM2.6",
+      "experiment_id": "one_percent",
+      "variable_id": "ocean_3d",
+      "zstore": "gs://cmip6/GFDL_CM2_6/one_percent/ocean_3d"
+    },
+    {
+      "institution_id": "NOAA-GFDL",
+      "source_id": "GFDL-CM2.6",
+      "experiment_id": "one_percent",
+      "variable_id": "ocean_boundary",
+      "zstore": "gs://cmip6/GFDL_CM2_6/one_percent/ocean_boundary"
+    },
+    {
+      "institution_id": "NOAA-GFDL",
+      "source_id": "GFDL-CM2.6",
+      "experiment_id": "one_percent",
+      "variable_id": "ocean_budgets",
+      "zstore": "gs://cmip6/GFDL_CM2_6/one_percent/ocean_budgets"
+    },
+    {
+      "institution_id": "NOAA-GFDL",
+      "source_id": "GFDL-CM2.6",
+      "experiment_id": "one_percent",
+      "variable_id": "ocean_transport",
+      "zstore": "gs://cmip6/GFDL_CM2_6/one_percent/ocean_transport"
+    },
+    {
+      "institution_id": "NOAA-GFDL",
+      "source_id": "GFDL-CM2.6",
+      "experiment_id": "one_percent",
+      "variable_id": "surface",
+      "zstore": "gs://cmip6/GFDL_CM2_6/one_percent/surface"
+    },
+    {
+      "institution_id": "NOAA-GFDL",
+      "source_id": "GFDL-CM2.6",
+      "experiment_id": "grid",
+      "variable_id": "grid",
+      "zstore": "gs://cmip6/GFDL_CM2_6/grid"
+    }
+  ],
+  "esm:attributes": ["institution_id", "source_id", "experiment_id", "variable_id"],
+  "esm:data_column_name": "zstore",
+  "esm:aggregation_control": {
+    "variable_column_name": "variable_id",
+    "groupby_attrs": [
+      "institution_id",
+      "source_id",
+      "experiment_id"
+    ],
+    "aggregations": [{
+      "type": "union",
+      "attribute_name": "variable_id"
+    }]
+  }
+}

--- a/examples/sample-catalog-dict-attribute.json
+++ b/examples/sample-catalog-dict-attribute.json
@@ -53,19 +53,19 @@
       "href": "https://raw.githubusercontent.com/WCRP-CMIP/CMIP6_CVs/master/CMIP6_institution_id.json",
       "type": "application/json",
       "roles": ["esm-vocabulary"],
-      "esm:column_name": "activity_id"
+      "esm:attribute_field": "activity_id"
     },
     "source_id": {
       "href": "https://raw.githubusercontent.com/WCRP-CMIP/CMIP6_CVs/master/CMIP6_source_id.json",
       "type": "application/json",
       "roles": ["esm-vocabulary"],
-      "esm:column_name": "source_id"
+      "esm:attribute_field": "source_id"
     },
     "experiment_id": {
       "href": "https://raw.githubusercontent.com/WCRP-CMIP/CMIP6_CVs/master/CMIP6_experiment_id.json",
       "type": "application/json",
       "roles": ["esm-vocabulary"],
-      "esm:column_name": "experiment_id"
+      "esm:attribute_field": "experiment_id"
     }
   },
   "esm:catalog": [{
@@ -163,7 +163,7 @@
   "esm:attributes": ["institution_id", "source_id", "experiment_id", "variable_id"],
   "esm:data_column_name": "zstore",
   "esm:aggregation_control": {
-    "variable_column_name": "variable_id",
+    "variable": "variable_id",
     "groupby_attrs": [
       "institution_id",
       "source_id",


### PR DESCRIPTION
Adds two implementations of [GFDL CM2.6's esm collection](https://storage.googleapis.com/cmip6/gfdl_cm2_6.json), based on our two ideas for handling internal `catalog_dict`s:

- Have all entries in an array under an attribute called `esm:catalog`
- Have all entries in assets with their own unique key