### PR TITLE
JSON Schema

### DIFF
--- a/json-schema/schema-full.json
+++ b/json-schema/schema-full.json
@@ -1,0 +1,488 @@
+{
+	"title": "ESM Extension Specification",
+	"description": "This object represents Collections in a Earth System Model Catalog.",
+	"allOf": [
+	  {
+		"$ref": "#/definitions/catalog"
+	  },
+	  {
+		"$ref": "#/definitions/collection"
+	  },
+	  {
+		"$ref": "#/definitions/assets"
+	  },
+	  {
+		"$ref": "#/definitions/esm"
+	  }
+	],
+	"definitions": {
+	  "esm": {
+		"type": "object",
+		"required": [
+		  "esm:attributes"
+		],
+		"properties": {
+		  "assets": {
+			"type": "object",
+			"additionalProperties": {
+			  "type": "object",
+			  "oneOf": [
+				{
+				  "allOf": [
+					{
+					  "$ref": "#/definitions/asset"
+					},
+					{
+					  "properties": {
+						"roles": {
+						  "type": "array",
+						  "items": {
+							"not": {
+							  "enum": [
+								"esm-catalog",
+								"esm-vocabulary",
+								"esm-data"
+							  ]
+							}
+						  }
+						}
+					  }
+					}
+				  ]
+				},
+				{
+				  "required": [
+					"type",
+					"roles",
+					"esm:data_field",
+					"esm:format"
+				  ],
+				  "properties": {
+					"type": {
+					  "type": "string",
+					  "const": "text/csv"
+					},
+					"roles": {
+					  "type": "array",
+					  "maxItems": 1,
+					  "items": {
+						"type": "string",
+						"const": "esm-catalog"
+					  }
+					},
+					"esm:data_field": {
+					  "title": "Column Name",
+					  "description": "The name of the column containing the path to the asset.",
+					  "type": "string"
+					},
+					"esm:format": {
+					  "title": "Format",
+					  "description": "File format of the assets.",
+					  "type": "string"
+					},
+					"esm:format_field": {
+					  "title": "Format Column Name",
+					  "description": "The column name which contains the data format.",
+					  "type": "string"
+					}
+				  }
+				},
+				{
+				  "required": [
+					"roles",
+					"esm:attribute_field"
+				  ],
+				  "properties": {
+					"roles": {
+					  "type": "array",
+					  "maxItems": 1,
+					  "items": {
+						"type": "string",
+						"const": "esm-vocabulary"
+					  }
+					},
+					"esm:attribute_field": {
+					  "title": "Column Name",
+					  "description": "The name of the column containing the path to the asset.",
+					  "type": "string"
+					}
+				  }
+				},
+				{
+				  "required": [
+					"roles"
+				  ],
+				  "properties": {
+					"roles": {
+					  "type": "array",
+					  "maxItems": 1,
+					  "items": {
+						"type": "string",
+						"const": "esm-data"
+					  }
+					}
+				  }
+				}
+			  ]
+			}
+		  },
+		  "esm:attributes": {
+			"title": "Attributes",
+			"description": "Asset attributes",
+			"type": "array",
+			"uniqueItems": true,
+			"items": {
+			  "type": "string",
+			  "description": "The name of the attribute column. Must be in the header of the CSV file."
+			}
+		  },
+		  "esm:aggregation_control": {
+			"type": "object",
+			"required": [
+			  "variable"
+			],
+			"properties": {
+			  "variable": {
+				"title": "Variable Column Name",
+				"description": "Name of the attribute column in csv file that contains the variable name.",
+				"type": "string"
+			  },
+			  "groupby_attrs": {
+				"title": "Group by attributes",
+				"description": "Column names (attributes) that define data sets that can be aggegrated.",
+				"type": "array"
+			  },
+			  "aggregations": {
+				"title": "Aggregation operations",
+				"description": "List of aggregations to apply to query results",
+				"type": "array",
+				"items": {
+				  "type": "object",
+				  "required": [
+					"type"
+				  ],
+				  "properties": {
+					"type": {
+					  "title": "Type of aggregration",
+					  "description": "Type of aggregation operation to apply.",
+					  "enum": [
+						"join_new",
+						"join_existing",
+						"union"
+					  ],
+					  "type": "string"
+					},
+					"attribute_name": {
+					  "title": "Name of attribute",
+					  "description": "Name of attribute across which to aggregate.",
+					  "type": "string"
+					},
+					"options": {
+					  "title": "Options",
+					  "description": "Optional aggregration settings that are passed as keywords arguments to xarray.concat or xarray.merge. For `join_existing`, must contain something like {'dim': 'time'}.",
+					  "type": "object"
+					}
+				  }
+				}
+			  }
+			}
+		  }
+		}
+	  },
+	  "asset": {
+		"type": "object",
+		"required": [
+		  "href"
+		],
+		"properties": {
+		  "href": {
+			"title": "Asset reference",
+			"type": "string"
+		  },
+		  "title": {
+			"title": "Asset title",
+			"type": "string"
+		  },
+		  "description": {
+			"title": "Asset description",
+			"type": "string"
+		  },
+		  "type": {
+			"title": "Asset type",
+			"type": "string"
+		  },
+		  "roles": {
+			"title": "Asset roles",
+			"type": "array",
+			"items": {
+			  "type": "string"
+			}
+		  }
+		}
+	  },
+	  "assets": {
+		"type": "object",
+		"required": [
+		  "assets"
+		],
+		"properties": {
+		  "assets": {
+			"title": "Asset links",
+			"description": "Links to assets",
+			"type": "object",
+			"additionalProperties": {
+			  "$ref": "#/definitions/asset"
+			}
+		  }
+		}
+	  },
+	  "catalog": {
+		"title": "Catalog",
+		"type": "object",
+		"required": [
+		  "stac_version",
+		  "id",
+		  "description",
+		  "links"
+		],
+		"properties": {
+		  "stac_version": {
+			"title": "STAC version",
+			"type": "string",
+			"const": "0.9.0"
+		  },
+		  "stac_extensions": {
+			"title": "STAC extensions",
+			"type": "array",
+			"uniqueItems": true,
+			"items": {
+			  "type": "string"
+			}
+		  },
+		  "id": {
+			"title": "Identifier",
+			"type": "string"
+		  },
+		  "title": {
+			"title": "Title",
+			"type": "string"
+		  },
+		  "description": {
+			"title": "Description",
+			"type": "string"
+		  },
+		  "links": {
+			"title": "Links",
+			"type": "array",
+			"items": {
+			  "type": "object",
+			  "required": [
+				"rel",
+				"href"
+			  ],
+			  "properties": {
+				"href": {
+				  "title": "Link reference",
+				  "type": "string"
+				},
+				"rel": {
+				  "title": "Link relation type",
+				  "type": "string"
+				},
+				"type": {
+				  "title": "Link type",
+				  "type": "string"
+				},
+				"title": {
+				  "title": "Link title",
+				  "type": "string"
+				}
+			  }
+			}
+		  }
+		}
+	  },
+	  "collection": {
+		"title": "STAC Collection",
+		"description": "These are the fields specific to a STAC Collection. All other fields are inherited from STAC Catalog.",
+		"type": "object",
+		"required": [
+		  "license",
+		  "extent"
+		],
+		"properties": {
+		  "stac_extensions": {
+			"title": "STAC extensions",
+			"type": "array",
+			"uniqueItems": true,
+			"items": {
+			  "anyOf": [
+				{
+				  "title": "Reference to a JSON Schema",
+				  "type": "string",
+				  "format": "uri"
+				},
+				{
+				  "title": "Reference to a core extension",
+				  "type": "string",
+				  "enum": [
+					"collection-assets",
+					"commons",
+					"checksum",
+					"datacube",
+					"item-asset",
+					"scientific",
+					"version"
+				  ]
+				}
+			  ]
+			}
+		  },
+		  "keywords": {
+			"title": "Keywords",
+			"type": "array",
+			"items": {
+			  "type": "string"
+			}
+		  },
+		  "license": {
+			"title": "Collection License Name",
+			"type": "string",
+			"pattern": "^[\\w\\-\\.\\+]+$"
+		  },
+		  "providers": {
+			"type": "array",
+			"items": {
+			  "properties": {
+				"name": {
+				  "title": "Organization name",
+				  "type": "string"
+				},
+				"description": {
+				  "title": "Organization description",
+				  "type": "string"
+				},
+				"roles": {
+				  "title": "Organization roles",
+				  "type": "array",
+				  "items": {
+					"type": "string",
+					"enum": [
+					  "producer",
+					  "licensor",
+					  "processor",
+					  "host"
+					]
+				  }
+				},
+				"url": {
+				  "title": "Organization homepage",
+				  "type": "string",
+				  "format": "url"
+				}
+			  }
+			}
+		  },
+		  "extent": {
+			"title": "Extents",
+			"type": "object",
+			"required": [
+			  "spatial",
+			  "temporal"
+			],
+			"properties": {
+			  "spatial": {
+				"title": "Spatial extent object",
+				"type": "object",
+				"required": [
+				  "bbox"
+				],
+				"properties": {
+				  "bbox": {
+					"title": "Spatial extents",
+					"type": "array",
+					"minItems": 1,
+					"items": {
+					  "title": "Spatial extent",
+					  "type": "array",
+					  "minItems": 4,
+					  "maxItems": 6,
+					  "items": {
+						"type": "number"
+					  }
+					}
+				  }
+				}
+			  },
+			  "temporal": {
+				"title": "Temporal extent object",
+				"type": "object",
+				"required": [
+				  "interval"
+				],
+				"properties": {
+				  "interval": {
+					"title": "Temporal extents",
+					"type": "array",
+					"minItems": 1,
+					"items": {
+					  "title": "Temporal extent",
+					  "type": "array",
+					  "minItems": 2,
+					  "maxItems": 2,
+					  "items": {
+						"type": [
+						  "string",
+						  "null"
+						],
+						"format": "date-time"
+					  }
+					}
+				  }
+				}
+			  }
+			}
+		  },
+		  "summaries": {
+			"type": "object",
+			"additionalProperties": {
+			  "oneOf": [
+				{
+				  "title": "Stats",
+				  "type": "object",
+				  "required": [
+					"min",
+					"max"
+				  ],
+				  "properties": {
+					"min": {
+					  "title": "Minimum value",
+					  "type": [
+						"number",
+						"string"
+					  ]
+					},
+					"max": {
+					  "title": "Maximum value",
+					  "type": [
+						"number",
+						"string"
+					  ]
+					}
+				  }
+				},
+				{
+				  "title": "Set of values",
+				  "type": "array",
+				  "minItems": 1,
+				  "items": {
+					"description": "Any data type could occur."
+				  }
+				}
+			  ]
+			}
+		  }
+		}
+	  }
+	}
+}

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -5,13 +5,13 @@
   "description": "This object represents Collections in a Earth System Model Catalog.",
   "allOf": [
     {
-      "$ref": "https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/collection-spec/json-schema/collection.json"
+      "$ref": "https://raw.githubusercontent.com/radiantearth/stac-spec/v1.0.0-beta.1/collection-spec/json-schema/collection.json"
     },
     {
-      "$ref": "https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/extensions/collection-assets/json-schema/schema.json"
+      "$ref": "https://raw.githubusercontent.com/radiantearth/stac-spec/v1.0.0-beta.1/extensions/collection-assets/json-schema/schema.json"
     },
     {
-	    "$ref": "#/definitions/esm"
+      "$ref": "#/definitions/esm"
     }
   ],
   "definitions": {
@@ -27,18 +27,29 @@
             "type": "object",
             "oneOf": [
               {
-                "not": {
-                  "required": [
-                    "roles"
-                  ],
-                  "roles": {
-                    "type": "array",
-                    "items": {
-                      "type": "string",
-                      "enum": ["esm-catalog", "esm-vocabulary", "esm-data"]
+                "allOf": [
+                  {
+                    "$ref": "https://raw.githubusercontent.com/radiantearth/stac-spec/v1.0.0-beta.1/item-spec/json-schema/item.json#/definitions/asset"
+                  },
+                  {
+                    "not": {
+                      "required": [
+                        "roles"
+                      ],
+                      "roles": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "enum": [
+                            "esm-catalog",
+                            "esm-vocabulary",
+                            "esm-data"
+                          ]
+                        }
+                      }
                     }
                   }
-                }
+                ]
               },
               {
                 "required": [

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -1,0 +1,183 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "schema.json#",
+  "title": "ESM Extension Specification",
+  "description": "This object represents Collections in a Earth System Model Catalog.",
+  "allOf": [
+    {
+      "$ref": "https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/collection-spec/json-schema/collection.json"
+    },
+    {
+      "$ref": "https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/extensions/collection-assets/json-schema/schema.json"
+    },
+    {
+	    "$ref": "#/definitions/esm"
+    }
+  ],
+  "definitions": {
+    "esm": {
+      "type": "object",
+      "required": [
+        "esm:attributes"
+      ],
+      "properties": {
+        "assets": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "oneOf": [
+              {
+                "not": {
+                  "required": [
+                    "roles"
+                  ],
+                  "roles": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": ["esm-catalog", "esm-vocabulary", "esm-data"]
+                    }
+                  }
+                }
+              },
+              {
+                "required": [
+                  "type",
+                  "roles",
+                  "esm:data_field",
+                  "esm:format"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "text/csv"
+                  },
+                  "roles": {
+                    "type": "array",
+                    "maxItems": 1,
+                    "items": {
+                      "type": "string",
+                      "const": "esm-catalog"
+                    }
+                  },
+                  "esm:data_field": {
+                    "title": "Column Name",
+                    "description": "The name of the column containing the path to the asset.",
+                    "type": "string"
+                  },
+                  "esm:format": {
+                    "title": "Format",
+                    "description": "File format of the assets.",
+                    "type": "string"
+                  },
+                  "esm:format_field": {
+                    "title": "Format Column Name",
+                    "description": "The column name which contains the data format.",
+                    "type": "string"
+                  }
+                }
+              },
+              {
+                "required": [
+                  "roles",
+                  "esm:attribute_field"
+                ],
+                "properties": {
+                  "roles": {
+                    "type": "array",
+                    "maxItems": 1,
+                    "items": {
+                      "type": "string",
+                      "const": "esm-vocabulary"
+                    }
+                  },
+                  "esm:attribute_field": {
+                    "title": "Column Name",
+                    "description": "The name of the column containing the path to the asset.",
+                    "type": "string"
+                  }
+                }
+              },
+              {
+                "required": [
+                  "roles"
+                ],
+                "properties": {
+                  "roles": {
+                    "type": "array",
+                    "maxItems": 1,
+                    "items": {
+                      "type": "string",
+                      "const": "esm-data"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "esm:attributes": {
+          "title": "Attributes",
+          "description": "Asset attributes",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "description": "The name of the attribute column. Must be in the header of the CSV file."
+          }
+        },
+        "esm:aggregation_control": {
+          "type": "object",
+          "required": [
+            "variable_field"
+          ],
+          "properties": {
+            "variable_field": {
+              "title": "Variable Column Name",
+              "description": "Name of the attribute column in csv file that contains the variable name.",
+              "type": "string"
+            },
+            "groupby_attrs": {
+              "title": "Group by attributes",
+              "description": "Column names (attributes) that define data sets that can be aggegrated.",
+              "type": "array"
+            },
+            "aggregations": {
+              "title": "Aggregation operations",
+              "description": "List of aggregations to apply to query results",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "title": "Type of aggregration",
+                    "description": "Type of aggregation operation to apply.",
+                    "enum": [
+                      "join_new",
+                      "join_existing",
+                      "union"
+                    ],
+                    "type": "string"
+                  },
+                  "attribute_name": {
+                    "title": "Name of attribute",
+                    "description": "Name of attribute across which to aggregate.",
+                    "type": "string"
+                  },
+                  "options": {
+                    "title": "Options",
+                    "description": "Optional aggregration settings that are passed as keywords arguments to xarray.concat or xarray.merge. For `join_existing`, must contain something like {'dim': 'time'}.",
+                    "type": "object"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The schema.json should be the source of truth later.

Just adding a full "dereferenced" schema in schema-full.json temporarily to quickly check examples with tools like  https://www.jsonschemavalidator.net/